### PR TITLE
Update Laravel Prompts Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^8.1",
         "symfony/console": "^7.0",
         "nunomaduro/termwind": "^2.0",
-        "laravel/prompts": "^0.1.12"
+        "laravel/prompts": "^0.1.12|^0.2.0|^0.3.0"
     },
     "conflict": {
         "illuminate/console": "*"


### PR DESCRIPTION
Updated the laravel prompts versions to work with those used within the `laravel/installer` package